### PR TITLE
fix(coverage): Expand external local repo in coverage report

### DIFF
--- a/src/bazel/tasks.ts
+++ b/src/bazel/tasks.ts
@@ -186,7 +186,7 @@ async function onTaskProcessEnd(event: vscode.TaskProcessEndEvent) {
         );
       } else {
         // The `bazel coverage` runs the build/test/coverage in sandboxes with
-        // the similar/same layout of execution root, thus making it as the base
+        // the similar/same layout of execution root, thus using it as the base
         // for mapping the source files.
         await showLcovCoverage(description, executionRoot, covFileStr);
       }

--- a/src/test-explorer/index.ts
+++ b/src/test-explorer/index.ts
@@ -30,6 +30,10 @@ export function activateTesting(): vscode.Disposable[] {
 
 /**
  * Display coverage information from a `.lcov` file.
+ *
+ * @param description The heading message for test (coverage) run.
+ * @param baseFolder The source file entries are relative paths to baseFolder.
+ * @param lcov The lcov report data in string.
  */
 export async function showLcovCoverage(
   description: string,


### PR DESCRIPTION
Rules under repo local_repository() are external repo but symlinked to a local path, usually in the same workspace.

No matter if the local path is in the same workspace, the users should usually want to check the local path specified in local_repository rules instead of the path in bazel output
(`<bazel workspace>/bazel-<repo>/external/...`) in
file explorer.

Works towards #416. Improves #362.