### PR TITLE
ci: Fix release please not running after repository move

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'bazelbuild/vscode-bazel' }}
+    if: ${{ github.repository == 'bazel-contrib/vscode-bazel' }}
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release


### PR DESCRIPTION
This action was being skipped since it ran based on repository name to avoid it running on forks, and the repository was moved to bazel-contrib recently.