### PR TITLE
refactor(workspace-tree): Refine event and dispose handling

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -41,7 +41,9 @@ import { activateWrapperCommands } from "./bazel_wrapper_commands";
  * @param context The extension context.
  */
 export async function activate(context: vscode.ExtensionContext) {
-  const workspaceTreeProvider = new BazelWorkspaceTreeProvider(context);
+  const workspaceTreeProvider = new BazelWorkspaceTreeProvider();
+  context.subscriptions.push(workspaceTreeProvider);
+
   const codeLensProvider = new BazelBuildCodeLensProvider(context);
   const buildifierDiagnostics = new BuildifierDiagnosticsManager();
   const completionItemProvider = new BazelCompletionItemProvider();

--- a/src/workspace-tree/bazel_workspace_tree_provider.ts
+++ b/src/workspace-tree/bazel_workspace_tree_provider.ts
@@ -25,9 +25,9 @@ export class BazelWorkspaceTreeProvider
   implements vscode.TreeDataProvider<IBazelTreeItem>, vscode.Disposable
 {
   /** Fired when BUILD files change in the workspace. */
-  private readonly _onDidChangeTreeData =
+  private readonly onDidChangeTreeDataEmitter =
     new vscode.EventEmitter<IBazelTreeItem | void>();
-  public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+  public readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
 
   /** The cached toplevel items. */
   private workspaceFolderTreeItems: BazelWorkspaceFolderTreeItem[] | undefined;
@@ -104,7 +104,7 @@ export class BazelWorkspaceTreeProvider
   /** Forces a re-query and refresh of the tree's contents. */
   public refresh() {
     this.updateWorkspaceFolderTreeItems();
-    this._onDidChangeTreeData.fire();
+    this.onDidChangeTreeDataEmitter.fire();
   }
 
   /**

--- a/src/workspace-tree/bazel_workspace_tree_provider.ts
+++ b/src/workspace-tree/bazel_workspace_tree_provider.ts
@@ -22,48 +22,37 @@ import { BazelWorkspaceFolderTreeItem } from "./bazel_workspace_folder_tree_item
  * interface.
  */
 export class BazelWorkspaceTreeProvider
-  implements vscode.TreeDataProvider<IBazelTreeItem>
+  implements vscode.TreeDataProvider<IBazelTreeItem>, vscode.Disposable
 {
-  public onDidChangeTreeData: vscode.Event<IBazelTreeItem | void>;
-
   /** Fired when BUILD files change in the workspace. */
-  private onDidChangeTreeDataEmitter =
+  private readonly _onDidChangeTreeData =
     new vscode.EventEmitter<IBazelTreeItem | void>();
+  public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
   /** The cached toplevel items. */
   private workspaceFolderTreeItems: BazelWorkspaceFolderTreeItem[] | undefined;
+
+  private disposables: vscode.Disposable[] = [];
 
   /**
    * Initializes a new tree provider with the given extension context.
    *
    * @param context The VS Code extension context.
    */
-  constructor(private context: vscode.ExtensionContext) {
-    this.onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
-
-    const buildWatcher = vscode.workspace.createFileSystemWatcher(
+  constructor() {
+    const buildFilesWatcher = vscode.workspace.createFileSystemWatcher(
       "**/{BUILD,BUILD.bazel}",
       false,
       false,
       false,
     );
-    buildWatcher.onDidChange(
-      () => this.onBuildFilesChanged(),
-      this,
-      context.subscriptions,
+    this.disposables.push(
+      buildFilesWatcher,
+      buildFilesWatcher.onDidChange(() => this.onBuildFilesChanged()),
+      buildFilesWatcher.onDidCreate(() => this.onBuildFilesChanged()),
+      buildFilesWatcher.onDidDelete(() => this.onBuildFilesChanged()),
+      vscode.workspace.onDidChangeWorkspaceFolders(() => this.refresh()),
     );
-    buildWatcher.onDidCreate(
-      () => this.onBuildFilesChanged(),
-      this,
-      context.subscriptions,
-    );
-    buildWatcher.onDidDelete(
-      () => this.onBuildFilesChanged(),
-      this,
-      context.subscriptions,
-    );
-
-    vscode.workspace.onDidChangeWorkspaceFolders(() => this.refresh(), this);
 
     this.updateWorkspaceFolderTreeItems();
   }
@@ -115,7 +104,7 @@ export class BazelWorkspaceTreeProvider
   /** Forces a re-query and refresh of the tree's contents. */
   public refresh() {
     this.updateWorkspaceFolderTreeItems();
-    this.onDidChangeTreeDataEmitter.fire();
+    this._onDidChangeTreeData.fire();
   }
 
   /**
@@ -154,5 +143,11 @@ export class BazelWorkspaceTreeProvider
       "bazel.haveWorkspace",
       haveBazelWorkspace,
     );
+  }
+
+  public dispose() {
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
   }
 }


### PR DESCRIPTION
Less dependency for BazelWorkspaceTreeProvider, making the future testing changes simpler.

Also small clean ups for this capturing and making the styles (naming and initializations) like
https://github.com/microsoft/vscode-extension-samples/blob/2f83557/tree-view-sample/src/nodeDependencies.ts