### PR TITLE
feat(workspace-tree): Workspace tree can show external local repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
                 },
                 "bazel.commandLine.queryExpression": {
                     "type": "string",
-                    "default": "...:*",
+                    "default": "",
                     "description": "A [query language expression](https://bazel.build/query/language) which determines the packages displayed in the workspace tree and quick picker. The default inspects the entire workspace, but you could narrow it. For example: `//part/you/want/...:*`"
                 },
                 "bazel.lsp.command": {

--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -19,6 +19,22 @@ import { blaze_query } from "../protos";
 import { BazelQuery } from "./bazel_query";
 
 /**
+ * Get the absolute path for a queried label.
+ *
+ * The queried package path are without leading double slash, while we want to
+ * provide with leading slash.
+ *
+ * @param label The label.
+ * @returns The label in absolute path.
+ */
+export function labelFromQueriedToAbsolute(label: string): string {
+  // External packages are in form `@repo//foo/bar`.
+  // Main repo relative label are in form `foo/bar`.
+  // Main repo absolute label are in form `//foo/bar`.
+  return label.includes("//") ? label : `//${label}`;
+}
+
+/**
  * Get the package label for a build file.
  *
  * @param workspace The path to the workspace.

--- a/src/bazel/bazel_workspace_info.ts
+++ b/src/bazel/bazel_workspace_info.ts
@@ -100,8 +100,8 @@ export class BazelWorkspaceInfo {
    * belong to a workspace folder (for example, a standalone file loaded
    * into the editor).
    */
-  private constructor(
+  constructor(
     public readonly bazelWorkspacePath: string,
-    public readonly workspaceFolder: vscode.WorkspaceFolder | undefined,
+    public readonly workspaceFolder?: vscode.WorkspaceFolder,
   ) {}
 }

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -32,3 +32,11 @@ export function getDefaultBazelExecutablePath(): string {
   }
   return bazelExecutable;
 }
+
+export function getDefaultQueryExpression(): string {
+  return (
+    vscode.workspace
+      .getConfiguration("bazel.commandLine")
+      .get<string>("queryExpression") ?? "...:*"
+  );
+}

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -14,15 +14,11 @@
 
 import * as vscode from "vscode";
 import { BazelWorkspaceInfo } from "../bazel";
-import {
-  BazelQuery,
-  IBazelCommandAdapter,
-  IBazelCommandOptions,
-} from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
+import { IBazelCommandAdapter, IBazelCommandOptions } from "../bazel";
 import { blaze_query } from "../protos";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
 import { IBazelTreeItem } from "./bazel_tree_item";
+import { IBazelQuerier } from "./querier";
 
 /** A tree item representing a build package. */
 export class BazelPackageTreeItem
@@ -32,7 +28,7 @@ export class BazelPackageTreeItem
    * The array of subpackages that should be shown directly under this package
    * item.
    */
-  public directSubpackages: BazelPackageTreeItem[] = [];
+  public directSubpackages: IBazelTreeItem[] = [];
 
   /**
    * Initializes a new tree item with the given workspace path and package path.
@@ -44,6 +40,7 @@ export class BazelPackageTreeItem
    * {@code packagePath} should be stripped for the item's label.
    */
   constructor(
+    private readonly querier: IBazelQuerier,
     private readonly workspaceInfo: BazelWorkspaceInfo,
     private readonly packagePath: string,
     private readonly parentPackagePath: string,
@@ -54,17 +51,14 @@ export class BazelPackageTreeItem
   }
 
   public async getChildren(): Promise<IBazelTreeItem[]> {
-    const queryResult = await new BazelQuery(
-      getDefaultBazelExecutablePath(),
-      this.workspaceInfo.bazelWorkspacePath,
-    ).queryTargets(`//${this.packagePath}:all`, {
-      ignoresErrors: true,
-      sortByRuleName: true,
-    });
+    const queryResult = await this.querier.queryChildrenTargets(
+      this.workspaceInfo,
+      this.packagePath,
+    );
     const targets = queryResult.target.map((target: blaze_query.ITarget) => {
       return new BazelTargetTreeItem(this.workspaceInfo, target);
     });
-    return (this.directSubpackages as IBazelTreeItem[]).concat(targets);
+    return this.directSubpackages.concat(targets);
   }
 
   public getLabel(): string {

--- a/src/workspace-tree/bazel_package_tree_item.ts
+++ b/src/workspace-tree/bazel_package_tree_item.ts
@@ -33,6 +33,7 @@ export class BazelPackageTreeItem
   /**
    * Initializes a new tree item with the given workspace path and package path.
    *
+   * @param querier Querier for getting information inside a Bazel workspace.
    * @param workspacePath The path to the VS Code workspace folder.
    * @param packagePath The path to the build package that this item represents.
    * @param parentPackagePath The path to the build package of the tree item
@@ -43,7 +44,7 @@ export class BazelPackageTreeItem
     private readonly querier: IBazelQuerier,
     private readonly workspaceInfo: BazelWorkspaceInfo,
     private readonly packagePath: string,
-    private readonly parentPackagePath: string,
+    private readonly parentPackagePath?: string,
   ) {}
 
   public mightHaveChildren(): boolean {
@@ -62,14 +63,23 @@ export class BazelPackageTreeItem
   }
 
   public getLabel(): string {
-    // If this is a top-level package, include the leading double-slash on the
-    // label.
-    if (this.parentPackagePath.length === 0) {
-      return `//${this.packagePath}`;
+    if (this.parentPackagePath === undefined) {
+      return this.packagePath;
     }
-    // Otherwise, strip off the part of the package path that came from the
-    // parent item (along with the slash).
-    return this.packagePath.substring(this.parentPackagePath.length + 1);
+    // Strip off the part of the package path that came from the
+    // parent item.
+    const parentLength = this.parentPackagePath.length;
+    // (null)
+    // //a
+    //
+    // @repo//foo
+    // @repo//foo/bar
+    //
+    // @repo//
+    // @repo//foo
+    const diffIsLeadingSlash = this.packagePath[parentLength] === "/";
+    const prefixLength = diffIsLeadingSlash ? parentLength + 1 : parentLength;
+    return this.packagePath.substring(prefixLength);
   }
 
   public getIcon(): vscode.ThemeIcon {
@@ -77,11 +87,11 @@ export class BazelPackageTreeItem
   }
 
   public getTooltip(): string {
-    return `//${this.packagePath}`;
+    return this.packagePath;
   }
 
-  public getCommand(): vscode.Command | undefined {
-    return undefined;
+  public getCommand(): Thenable<vscode.Command | undefined> {
+    return Promise.resolve(undefined);
   }
 
   public getContextValue(): string {
@@ -91,7 +101,7 @@ export class BazelPackageTreeItem
   public getBazelCommandOptions(): IBazelCommandOptions {
     return {
       options: [],
-      targets: [`//${this.packagePath}`],
+      targets: [this.packagePath],
       workspaceInfo: this.workspaceInfo,
     };
   }

--- a/src/workspace-tree/bazel_target_tree_item.ts
+++ b/src/workspace-tree/bazel_target_tree_item.ts
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
+import * as fs from "fs/promises";
 import { BazelWorkspaceInfo, QueryLocation } from "../bazel";
 import { IBazelCommandAdapter, IBazelCommandOptions } from "../bazel";
 import { blaze_query } from "../protos";
 import { IBazelTreeItem } from "./bazel_tree_item";
 import { getBazelRuleIcon } from "./icons";
+import { BazelInfo } from "../bazel/bazel_info";
+import { getDefaultBazelExecutablePath } from "../extension/configuration";
 
 /** A tree item representing a build target. */
 export class BazelTargetTreeItem
@@ -27,6 +30,7 @@ export class BazelTargetTreeItem
    * Initializes a new tree item with the given query result representing a
    * build target.
    *
+   * @param querier Querier for getting information inside a Bazel workspace.
    * @param target An object representing a build target that was produced by a
    * query.
    */
@@ -55,16 +59,36 @@ export class BazelTargetTreeItem
   }
 
   public getTooltip(): string {
-    return `${this.target.rule.name}`;
+    return this.target.rule.name;
   }
 
-  public getCommand(): vscode.Command | undefined {
+  public async getCommand(): Promise<vscode.Command | undefined> {
+    // Resolve the prefix if prefix is
+    // $(./prebuilts/bazel info output_base)/external/
     const location = new QueryLocation(this.target.rule.location);
+    // Maybe we should cache this to prevent the repeating invocations.
+    const outputBase = await new BazelInfo(
+      getDefaultBazelExecutablePath(),
+      this.workspaceInfo.workspaceFolder.uri.fsPath,
+    ).getOne("output_base");
+    let locationPath = location.path;
+    // If location is in pattern `${execRoot}/external/<repo>/...`, then it
+    // should be a file in local_repository(). Trying to remapping it back to
+    // the origin source folder by resolve the symlink
+    // ${execRoot}/external/<repo>.
+    const outputBaseExternalPath = `${outputBase}/external/`;
+    if (location.path.startsWith(outputBaseExternalPath)) {
+      const repoPath = location.path.substring(outputBaseExternalPath.length);
+      const repoPathMatch = repoPath.match(/^([^/]+)\/(.*)$/);
+      if (repoPathMatch.length === 3) {
+        const repo = repoPathMatch[1];
+        const rest = repoPathMatch[2];
+        const realRepo = await fs.realpath(`${outputBaseExternalPath}${repo}`);
+        locationPath = `${realRepo}/${rest}`;
+      }
+    }
     return {
-      arguments: [
-        vscode.Uri.file(location.path),
-        { selection: location.range },
-      ],
+      arguments: [vscode.Uri.file(locationPath), { selection: location.range }],
       command: "vscode.open",
       title: "Jump to Build Target",
     };
@@ -81,7 +105,7 @@ export class BazelTargetTreeItem
   public getBazelCommandOptions(): IBazelCommandOptions {
     return {
       options: [],
-      targets: [`${this.target.rule.name}`],
+      targets: [this.target.rule.name],
       workspaceInfo: this.workspaceInfo,
     };
   }

--- a/src/workspace-tree/bazel_tree_item.ts
+++ b/src/workspace-tree/bazel_tree_item.ts
@@ -46,7 +46,7 @@ export interface IBazelTreeItem {
   getTooltip(): string | undefined;
 
   /** Returns the command that should be executed when the item is selected. */
-  getCommand(): vscode.Command | undefined;
+  getCommand(): Thenable<vscode.Command | undefined>;
 
   /**
    * Returns an identifying string that is used to filter which commands are

--- a/src/workspace-tree/bazel_workspace_folder_tree_item.ts
+++ b/src/workspace-tree/bazel_workspace_folder_tree_item.ts
@@ -14,12 +14,11 @@
 
 import * as vscode from "vscode";
 import { BazelWorkspaceInfo } from "../bazel";
-import { BazelQuery } from "../bazel";
-import { getDefaultBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 import { BazelPackageTreeItem } from "./bazel_package_tree_item";
 import { BazelTargetTreeItem } from "./bazel_target_tree_item";
 import { IBazelTreeItem } from "./bazel_tree_item";
+import { IBazelQuerier } from "./querier";
 
 /** A tree item representing a workspace folder. */
 export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
@@ -28,7 +27,10 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
    *
    * @param workspaceFolder The workspace folder that the tree item represents.
    */
-  constructor(private workspaceInfo: BazelWorkspaceInfo) {}
+  constructor(
+    private readonly querier: IBazelQuerier,
+    private readonly workspaceInfo: BazelWorkspaceInfo,
+  ) {}
 
   public mightHaveChildren(): boolean {
     return true;
@@ -78,7 +80,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     packagePaths: string[],
     startIndex: number,
     endIndex: number,
-    treeItems: BazelPackageTreeItem[],
+    treeItems: IBazelTreeItem[],
     parentPackagePath: string,
   ) {
     // We can assume that the caller has sorted the packages, so we scan them to
@@ -123,6 +125,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
       // tree node for the element at groupStart and then recursively call the
       // algorithm again to group its children.
       const item = new BazelPackageTreeItem(
+        this.querier,
         this.workspaceInfo,
         packagePath,
         parentPackagePath,
@@ -156,15 +159,7 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
     if (!this.workspaceInfo) {
       return Promise.resolve([] as IBazelTreeItem[]);
     }
-    const workspacePath = this.workspaceInfo.workspaceFolder.uri.fsPath;
-    const packagePaths = await new BazelQuery(
-      getDefaultBazelExecutablePath(),
-      workspacePath,
-    ).queryPackages(
-      vscode.workspace
-        .getConfiguration("bazel.commandLine")
-        .get("queryExpression"),
-    );
+    const packagePaths = await this.querier.queryPackages(this.workspaceInfo);
     const topLevelItems: BazelPackageTreeItem[] = [];
     this.buildPackageTree(
       packagePaths,
@@ -176,13 +171,10 @@ export class BazelWorkspaceFolderTreeItem implements IBazelTreeItem {
 
     // Now collect any targets in the directory also (this can fail since
     // there might not be a BUILD files at this level (but down levels)).
-    const queryResult = await new BazelQuery(
-      getDefaultBazelExecutablePath(),
-      workspacePath,
-    ).queryTargets(`:all`, {
-      ignoresErrors: true,
-      sortByRuleName: true,
-    });
+    const queryResult = await this.querier.queryChildrenTargets(
+      this.workspaceInfo,
+      "",
+    );
     const targets = queryResult.target.map((target: blaze_query.ITarget) => {
       return new BazelTargetTreeItem(this.workspaceInfo, target);
     });

--- a/src/workspace-tree/bazel_workspace_tree_provider.ts
+++ b/src/workspace-tree/bazel_workspace_tree_provider.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
-import { BazelWorkspaceInfo } from "../bazel";
+import { assert } from "../assert";
 import { IBazelTreeItem } from "./bazel_tree_item";
 import { BazelWorkspaceFolderTreeItem } from "./bazel_workspace_folder_tree_item";
 import { IBazelQuerier, ProcessBazelQuerier } from "./querier";
@@ -31,67 +31,70 @@ export class BazelWorkspaceTreeProvider
   public readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
 
   /** The cached toplevel items. */
-  private workspaceFolderTreeItems: BazelWorkspaceFolderTreeItem[] | undefined;
+  private workspaceFolderTreeItems?: IBazelTreeItem[];
 
   private disposables: vscode.Disposable[] = [];
 
-  /**
-   * Initializes a new tree provider with the given extension context.
-   *
-   * @param context The VS Code extension context.
-   * @param querier The interface providing the `bazel query` results.
-   */
-  constructor(
-    private readonly querier: IBazelQuerier = new ProcessBazelQuerier(),
-  ) {
+  public static async forExtension(): Promise<BazelWorkspaceTreeProvider> {
+    const workspaceTreeProvider = new BazelWorkspaceTreeProvider(
+      new ProcessBazelQuerier(),
+    );
+
+    const refreshWorkspaceFolders = () =>
+      workspaceTreeProvider.refresh(vscode.workspace.workspaceFolders);
+
+    workspaceTreeProvider.disposables.push(
+      vscode.workspace.onDidChangeWorkspaceFolders(refreshWorkspaceFolders),
+    );
+
     const buildFilesWatcher = vscode.workspace.createFileSystemWatcher(
       "**/{BUILD,BUILD.bazel}",
       false,
       false,
       false,
     );
-    this.disposables.push(
+    workspaceTreeProvider.disposables.push(
       buildFilesWatcher,
-      buildFilesWatcher.onDidChange(() => this.onBuildFilesChanged()),
-      buildFilesWatcher.onDidCreate(() => this.onBuildFilesChanged()),
-      buildFilesWatcher.onDidDelete(() => this.onBuildFilesChanged()),
-      vscode.workspace.onDidChangeWorkspaceFolders(() => this.refresh()),
+      buildFilesWatcher.onDidChange(refreshWorkspaceFolders),
+      buildFilesWatcher.onDidCreate(refreshWorkspaceFolders),
+      buildFilesWatcher.onDidDelete(refreshWorkspaceFolders),
     );
 
-    this.updateWorkspaceFolderTreeItems();
+    await refreshWorkspaceFolders();
+
+    return workspaceTreeProvider;
   }
 
-  public getChildren(element?: IBazelTreeItem): Thenable<IBazelTreeItem[]> {
+  /**
+   * @param querier The interface providing the `bazel query` results.
+   */
+  constructor(private readonly querier: IBazelQuerier) {}
+
+  public async getChildren(
+    element?: IBazelTreeItem,
+  ): Promise<IBazelTreeItem[]> {
     // If we're given an element, we're not asking for the top-level elements,
     // so just delegate to that element to get its children.
     if (element) {
       return element.getChildren();
     }
 
-    if (this.workspaceFolderTreeItems === undefined) {
-      this.updateWorkspaceFolderTreeItems();
+    // Assuming the extension or test cases should call refresh at least once.
+    assert(this.workspaceFolderTreeItems !== undefined);
+
+    // If the user has a workspace open and there's only one folder in it, then
+    // don't show the workspace folder; just show its packages at the top level.
+    if (this.workspaceFolderTreeItems.length === 1) {
+      const folderItem = this.workspaceFolderTreeItems[0];
+      return folderItem.getChildren();
     }
 
-    if (this.workspaceFolderTreeItems && vscode.workspace.workspaceFolders) {
-      // If the user has a workspace open and there's only one folder in it,
-      // then don't show the workspace folder; just show its packages at the top
-      // level.
-      if (vscode.workspace.workspaceFolders.length === 1) {
-        const folderItem = this.workspaceFolderTreeItems[0];
-        return folderItem.getChildren();
-      }
-
-      // If the user has multiple workspace folders open, then show them as
-      // individual top level items.
-      return Promise.resolve(this.workspaceFolderTreeItems);
-    }
-
-    // If the user doesn't have a folder open in the workspace, or none of them
-    // have Bazel workspaces, don't show anything.
-    return Promise.resolve([]);
+    // If the user has multiple or no workspace folders open, then show them as
+    // individual top level items.
+    return this.workspaceFolderTreeItems;
   }
 
-  public getTreeItem(element: IBazelTreeItem): vscode.TreeItem {
+  public async getTreeItem(element: IBazelTreeItem): Promise<vscode.TreeItem> {
     const label = element.getLabel();
     const collapsibleState = element.mightHaveChildren()
       ? vscode.TreeItemCollapsibleState.Collapsed
@@ -101,51 +104,60 @@ export class BazelWorkspaceTreeProvider
     treeItem.contextValue = element.getContextValue();
     treeItem.iconPath = element.getIcon();
     treeItem.tooltip = element.getTooltip();
-    treeItem.command = element.getCommand();
+    treeItem.command = await element.getCommand();
     return treeItem;
   }
 
-  /** Forces a re-query and refresh of the tree's contents. */
-  public refresh() {
-    this.updateWorkspaceFolderTreeItems();
+  /** Forces a re-query and refresh of the tree's contents.
+   *
+   * Also for initialize or to update the tree when a BUILD file is created,
+   * deleted, or changed.
+   */
+  public async refresh(
+    workspaceFolders: readonly vscode.WorkspaceFolder[],
+  ): Promise<void> {
+    await this.updateWorkspaceFolderTreeItems(workspaceFolders);
     this.onDidChangeTreeDataEmitter.fire();
   }
 
-  /**
-   * Called to update the tree when a BUILD file is created, deleted, or
-   * changed.
-   *
-   * @param uri The file system URI of the file that changed.
-   */
-  private onBuildFilesChanged() {
-    // TODO(allevato): Look into firing the event only for tree items that are
-    // affected by the change.
-    this.refresh();
+  private async createWorkspaceFolderTreeItem(
+    workspaceFolder: vscode.WorkspaceFolder,
+  ): Promise<BazelWorkspaceFolderTreeItem | undefined> {
+    const workspaceInfo = await this.querier.queryWorkspace(workspaceFolder);
+    if (workspaceInfo === undefined) {
+      return undefined;
+    }
+    return new BazelWorkspaceFolderTreeItem(this.querier, workspaceInfo);
   }
 
-  /** Refresh the cached BazelWorkspaceFolderTreeItems. */
-  private updateWorkspaceFolderTreeItems() {
-    if (vscode.workspace.workspaceFolders) {
-      this.workspaceFolderTreeItems = vscode.workspace.workspaceFolders
-        .map((folder) => {
-          const workspaceInfo = BazelWorkspaceInfo.fromWorkspaceFolder(folder);
-          if (workspaceInfo) {
-            return new BazelWorkspaceFolderTreeItem(
-              this.querier,
-              workspaceInfo,
-            );
-          }
-          return undefined;
-        })
-        .filter((folder) => folder !== undefined);
-    } else {
-      this.workspaceFolderTreeItems = [];
-    }
+  private async createWorkspaceFolderTreeItems(
+    workspaceFolders: readonly vscode.WorkspaceFolder[],
+  ): Promise<BazelWorkspaceFolderTreeItem[]> {
+    const maybeWorkspaceFolderTreeItems = await Promise.all(
+      workspaceFolders.map((workspaceFolder) =>
+        this.createWorkspaceFolderTreeItem(workspaceFolder),
+      ),
+    );
+    return maybeWorkspaceFolderTreeItems.filter(
+      (folder) => folder !== undefined,
+    );
+  }
 
-    // All the UI to update based on having items.
+  /**
+   * Update the cached BazelWorkspaceFolderTreeItems and other UI components
+   * interested in.
+   */
+  private async updateWorkspaceFolderTreeItems(
+    workspaceFolders?: readonly vscode.WorkspaceFolder[],
+  ): Promise<void> {
+    this.workspaceFolderTreeItems = await this.createWorkspaceFolderTreeItems(
+      workspaceFolders ?? [],
+    );
+
+    // Updates other UI components based on the context value for Bazel
+    // workspace.
     const haveBazelWorkspace = this.workspaceFolderTreeItems.length !== 0;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    vscode.commands.executeCommand(
+    void vscode.commands.executeCommand(
       "setContext",
       "bazel.haveWorkspace",
       haveBazelWorkspace,

--- a/src/workspace-tree/bazel_workspace_tree_provider.ts
+++ b/src/workspace-tree/bazel_workspace_tree_provider.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 import { BazelWorkspaceInfo } from "../bazel";
 import { IBazelTreeItem } from "./bazel_tree_item";
 import { BazelWorkspaceFolderTreeItem } from "./bazel_workspace_folder_tree_item";
+import { IBazelQuerier, ProcessBazelQuerier } from "./querier";
 
 /**
  * Provides a tree of Bazel build packages and targets for the VS Code explorer
@@ -38,8 +39,11 @@ export class BazelWorkspaceTreeProvider
    * Initializes a new tree provider with the given extension context.
    *
    * @param context The VS Code extension context.
+   * @param querier The interface providing the `bazel query` results.
    */
-  constructor() {
+  constructor(
+    private readonly querier: IBazelQuerier = new ProcessBazelQuerier(),
+  ) {
     const buildFilesWatcher = vscode.workspace.createFileSystemWatcher(
       "**/{BUILD,BUILD.bazel}",
       false,
@@ -126,7 +130,10 @@ export class BazelWorkspaceTreeProvider
         .map((folder) => {
           const workspaceInfo = BazelWorkspaceInfo.fromWorkspaceFolder(folder);
           if (workspaceInfo) {
-            return new BazelWorkspaceFolderTreeItem(workspaceInfo);
+            return new BazelWorkspaceFolderTreeItem(
+              this.querier,
+              workspaceInfo,
+            );
           }
           return undefined;
         })

--- a/src/workspace-tree/index.ts
+++ b/src/workspace-tree/index.ts
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 export * from "./bazel_workspace_tree_provider";
+export * from "./querier";

--- a/src/workspace-tree/querier.ts
+++ b/src/workspace-tree/querier.ts
@@ -1,0 +1,108 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as vscode from "vscode";
+import {
+  BazelQuery,
+  BazelWorkspaceInfo,
+  labelFromQueriedToAbsolute,
+} from "../bazel";
+import {
+  getDefaultBazelExecutablePath,
+  getDefaultQueryExpression,
+} from "../extension/configuration";
+import { blaze_query } from "../protos";
+import { BazelInfo } from "../bazel/bazel_info";
+
+/**
+ * Bazel querier for workspace tree.
+ *
+ * The interface defined here is to specifying the operation required for a
+ * workspace tree instead of all bazel query syntax and options supported.
+ *
+ * The function named with queryXxx are all for querying bazel informations.
+ */
+export interface IBazelQuerier {
+  /**
+   * Queries bazel workspace path by given vscode workspace folder.
+   *
+   * @param workspaceInfo the Bazel workspace info.
+   * @returns package name queries in absolute apparent paths.
+   */
+  queryWorkspace(
+    workspaceFolder: vscode.WorkspaceFolder,
+  ): Thenable<BazelWorkspaceInfo | undefined>;
+
+  /**
+   * Queries all Bazel packages in a workspace folder.
+   *
+   * @param workspaceInfo the Bazel workspace info.
+   * @returns package name queries in absolute apparent paths.
+   */
+  queryPackages(workspaceInfo: BazelWorkspaceInfo): Thenable<string[]>;
+
+  /**
+   * Queries all children targets of a Bazel package.
+   *
+   * @param workspaceInfo the Bazel workspace info.
+   * @param packagePath the Bazel package path. Could be either in absolute label or
+   * relative to the opening vscode workspace in `workspaceInfo`.
+   */
+  queryChildrenTargets(
+    workspaceInfo: BazelWorkspaceInfo,
+    packagePath: string,
+  ): Thenable<blaze_query.IQueryResult>;
+}
+
+/**
+ * Calling Bazel process for the queries.
+ */
+export class ProcessBazelQuerier implements IBazelQuerier {
+  async queryWorkspace(
+    workspaceFolder: vscode.WorkspaceFolder,
+  ): Promise<BazelWorkspaceInfo | undefined> {
+    try {
+      const bazelWorkspacePath = await new BazelInfo(
+        getDefaultBazelExecutablePath(),
+        workspaceFolder.uri.fsPath,
+      ).getOne("workspace");
+      return new BazelWorkspaceInfo(bazelWorkspacePath, workspaceFolder);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async queryPackages(workspaceInfo: BazelWorkspaceInfo): Promise<string[]> {
+    const packages = await new BazelQuery(
+      getDefaultBazelExecutablePath(),
+      workspaceInfo.workspaceFolder.uri.fsPath,
+    ).queryPackages(getDefaultQueryExpression());
+    return packages.map(labelFromQueriedToAbsolute);
+  }
+
+  queryChildrenTargets(
+    workspaceInfo: BazelWorkspaceInfo,
+    packagePath: string,
+  ): Promise<blaze_query.IQueryResult> {
+    // Getting all rules without files, thus using :all instead of :*.
+    const query = `${packagePath}:all`;
+    return new BazelQuery(
+      getDefaultBazelExecutablePath(),
+      workspaceInfo.workspaceFolder.uri.fsPath,
+    ).queryTargets(query, {
+      ignoresErrors: true,
+      sortByRuleName: true,
+    });
+  }
+}

--- a/test/workspace-tree.test.ts
+++ b/test/workspace-tree.test.ts
@@ -1,0 +1,206 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { BazelWorkspaceInfo } from "../src/bazel";
+import { blaze_query } from "../src/protos";
+import {
+  BazelWorkspaceTreeProvider,
+  IBazelQuerier,
+} from "../src/workspace-tree";
+
+class FakeBazelQuerier implements IBazelQuerier {
+  constructor(
+    private readonly packages: string[],
+    private readonly targets: Map<string, blaze_query.IQueryResult>,
+  ) {}
+
+  queryWorkspace(
+    workspaceFolder: vscode.WorkspaceFolder,
+  ): Thenable<BazelWorkspaceInfo | undefined> {
+    // Assuming query from root for simplest test case. (single root)
+    return Promise.resolve(
+      new BazelWorkspaceInfo(workspaceFolder.uri.fsPath, workspaceFolder),
+    );
+  }
+
+  queryPackages(workspaceInfo: BazelWorkspaceInfo): Thenable<string[]> {
+    void workspaceInfo;
+    return Promise.resolve(this.packages);
+  }
+
+  queryChildrenTargets(
+    workspaceInfo: BazelWorkspaceInfo,
+    packagePath: string,
+  ): Thenable<blaze_query.IQueryResult> {
+    void workspaceInfo;
+    return Promise.resolve(this.targets.get(packagePath));
+  }
+}
+
+function fakeWorkspaceFolder(path: string): vscode.WorkspaceFolder {
+  const uri = vscode.Uri.file(path);
+  return {
+    uri,
+    name: path,
+    index: 0,
+  };
+}
+
+async function workspaceTreeProviderForTest(
+  querier: IBazelQuerier,
+  workspaceFolders: vscode.WorkspaceFolder[],
+): Promise<BazelWorkspaceTreeProvider> {
+  const provider = new BazelWorkspaceTreeProvider(querier);
+  await provider.refresh(workspaceFolders);
+  return provider;
+}
+
+describe("The Bazel workspace tree provider", () => {
+  it("Returns nothing on empty workspace folders", async () => {
+    const querier = new FakeBazelQuerier([], new Map());
+    const workspaceFolders: vscode.WorkspaceFolder[] = [];
+    const provider = await workspaceTreeProviderForTest(
+      querier,
+      workspaceFolders,
+    );
+
+    const topChildren = await provider.getChildren();
+    assert.deepStrictEqual(topChildren, []);
+  });
+
+  it("Flatten on single workspace folder", async () => {
+    const querier = new FakeBazelQuerier(
+      ["//a"],
+      new Map([
+        ["", { target: [] }],
+        ["//a", { target: [] }],
+      ]),
+    );
+    const workspaceFolders: vscode.WorkspaceFolder[] = [
+      fakeWorkspaceFolder("fake/path"),
+    ];
+    const provider = await workspaceTreeProviderForTest(
+      querier,
+      workspaceFolders,
+    );
+
+    const topChildren = await provider.getChildren();
+    assert.equal(topChildren[0].getLabel(), "//a");
+  });
+
+  it("Not flatten on 2 workspace folders", async () => {
+    const querier = new FakeBazelQuerier([], new Map([["", { target: [] }]]));
+    const workspaceFolders: vscode.WorkspaceFolder[] = [
+      fakeWorkspaceFolder("fake/path0"),
+      fakeWorkspaceFolder("fake/path1"),
+    ];
+    const provider = await workspaceTreeProviderForTest(
+      querier,
+      workspaceFolders,
+    );
+
+    const topChildren = await provider.getChildren();
+    assert.equal(topChildren[0].getLabel(), "fake/path0");
+    assert.equal(topChildren[1].getLabel(), "fake/path1");
+  });
+
+  it("Can handle root package", async () => {
+    const querier = new FakeBazelQuerier(
+      ["//", "//a"],
+      new Map([
+        ["", { target: [] }],
+        ["//", { target: [] }],
+        ["//a", { target: [] }],
+      ]),
+    );
+    const workspaceFolders: vscode.WorkspaceFolder[] = [
+      fakeWorkspaceFolder("fake/path"),
+    ];
+    const provider = await workspaceTreeProviderForTest(
+      querier,
+      workspaceFolders,
+    );
+
+    const topChildren = await provider.getChildren();
+    const root = topChildren[0];
+    assert.equal(root.getLabel(), "//");
+    const rootChildren = await root.getChildren();
+    const a = rootChildren[0];
+    assert.equal(a.getLabel(), "a");
+  });
+
+  it("Skips non-package folders", async () => {
+    const querier = new FakeBazelQuerier(
+      ["//a", "//a/b/c"],
+      new Map([
+        ["", { target: [] }],
+        ["//a", { target: [] }],
+        ["//a/b/c", { target: [] }],
+      ]),
+    );
+    const workspaceFolders: vscode.WorkspaceFolder[] = [
+      fakeWorkspaceFolder("fake/path"),
+    ];
+    const provider = await workspaceTreeProviderForTest(
+      querier,
+      workspaceFolders,
+    );
+
+    const topChildren = await provider.getChildren();
+    const a = topChildren[0];
+    assert.equal(a.getLabel(), "//a");
+    const aChildren = await topChildren[0].getChildren();
+    const bc = aChildren[0];
+    assert.equal(bc.getLabel(), "b/c");
+  });
+
+  it("Handles external dependencies (single workspace)", async () => {
+    const querier = new FakeBazelQuerier(
+      [
+        "@repo//",
+        "@repo2//a",
+        "@repo2//a/b",
+        "@repo2//c",
+        "@repo2//c/d/e",
+        "@repo3//f",
+      ],
+      new Map([
+        ["", { target: [] }],
+        ["@repo//", { target: [] }],
+        ["@repo2//a", { target: [] }],
+        ["@repo2//a/b", { target: [] }],
+        ["@repo2//c", { target: [] }],
+        ["@repo2//c/d/e", { target: [] }],
+        ["@repo3//f", { target: [] }],
+      ]),
+    );
+    const workspaceFolders: vscode.WorkspaceFolder[] = [
+      fakeWorkspaceFolder("fake/path"),
+    ];
+    const provider = await workspaceTreeProviderForTest(
+      querier,
+      workspaceFolders,
+    );
+
+    const topChildren = await provider.getChildren();
+    const repo = topChildren[0];
+    assert.strictEqual(repo.getLabel(), "@repo//");
+    assert.strictEqual((await repo.getChildren()).length, 0);
+
+    const repo2a = topChildren[1];
+    assert.strictEqual(repo2a.getLabel(), "@repo2//a");
+    const repo2aChildren = await repo2a.getChildren();
+    const repo2ab = repo2aChildren[0];
+    assert.strictEqual(repo2ab.getLabel(), "b");
+
+    const repo2c = topChildren[2];
+    assert.strictEqual(repo2c.getLabel(), "@repo2//c");
+    const repo2cChildren = await repo2c.getChildren();
+    const repo2cde = repo2cChildren[0];
+    assert.strictEqual(repo2cde.getLabel(), "d/e");
+
+    const repo3f = topChildren[3];
+    assert.strictEqual(repo3f.getLabel(), "@repo3//f");
+  });
+
+  // TODO query target test cases.
+});


### PR DESCRIPTION
Besides the existing internal packages, handles handles external local repository: the packages in pattern `@repo//package/path:target`.

For building the tree structure:
- We made the `WorkspaceTreeProvider` able to process only the following two patterns, then normalize the patterns queried in `IBazelQuerier`:
  1. `//internal/package/path`
  2. `@external//package/path`
- The algorithm for building and grouping the queried packages are mostly remained.
- Simple test cases also added for package path handling, with corresponding refactors and clean ups.

UI:
- Expand the symlink for local repository target in `BazelTargetTreeItem.getCommand()`, so that clicking the targets in external local repository would jump into the source tree instead of Bazel cache path.

Misc:
- Also fixes some floating promises in edited files by explicitly marking them `void` for not waiting command/message, or properly grouping them into a promise for await.