### PR TITLE
feat(lsp): Add option to trace LSP communication

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,16 @@
                     },
                     "default": [],
                     "description": "The arguments to pass to the LSP executable"
+                },
+                "bazel.trace.server": {
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "default": "off",
+                    "description": "Trace the communication between VS Code and Bazel LSP server (language server)."
                 }
             }
         },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -161,7 +161,7 @@ function createLsp(config: vscode.WorkspaceConfiguration) {
     documentSelector: [{ scheme: "file", language: "starlark" }],
   };
 
-  return new LanguageClient("Bazel LSP Client", serverOptions, clientOptions);
+  return new LanguageClient("bazel", "Bazel LSP Client", serverOptions, clientOptions)
 }
 
 /**

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -161,7 +161,12 @@ function createLsp(config: vscode.WorkspaceConfiguration) {
     documentSelector: [{ scheme: "file", language: "starlark" }],
   };
 
-  return new LanguageClient("bazel", "Bazel LSP Client", serverOptions, clientOptions)
+  return new LanguageClient(
+    "bazel",
+    "Bazel LSP Client",
+    serverOptions,
+    clientOptions,
+  );
 }
 
 /**


### PR DESCRIPTION
This option is useful to see messages passed between VS and LSP server to debug issues in LSP server implementations.

Similar functionality is for many other languages, see e.g. previous changes for go and rust:

https://github.com/golang/vscode-go/commit/70e7c4bd3ac06de9f9b4cdeac88ce8681f60ab52
https://github.com/rust-lang/rust-analyzer/pull/302/files