### PR TITLE
feat(navigation): Add 'Copy Label To Clipboard' to command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
             },
             {
                 "category": "Bazel",
-                "command": "bazel.copyTargetToClipboard",
+                "command": "bazel.copyLabelToClipboard",
                 "title": "Copy Label to Clipboard"
             },
             {
@@ -322,8 +322,8 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "bazel.copyTargetToClipboard",
-                    "when": "false"
+                    "command": "bazel.copyLabelToClipboard",
+                    "when": "bazel.haveWorkspace"
                 },
                 {
                     "command": "bazel.buildTarget",
@@ -422,12 +422,12 @@
                     "group": "build"
                 },
                 {
-                    "command": "bazel.copyTargetToClipboard",
+                    "command": "bazel.copyLabelToClipboard",
                     "when": "view == bazelWorkspace && viewItem == rule",
                     "group": "build"
                 },
                 {
-                    "command": "bazel.copyTargetToClipboard",
+                    "command": "bazel.copyLabelToClipboard",
                     "when": "view == bazelWorkspace && viewItem == testRule",
                     "group": "build"
                 }

--- a/src/codelens/bazel_build_code_lens_provider.ts
+++ b/src/codelens/bazel_build_code_lens_provider.ts
@@ -147,7 +147,7 @@ export class BazelBuildCodeLensProvider implements vscode.CodeLensProvider {
 
       // All targets support target copying and building.
       commands.push({
-        commandString: "bazel.copyTargetToClipboard",
+        commandString: "bazel.copyLabelToClipboard",
         name: "Copy",
       });
       commands.push({

--- a/src/extension/bazel_wrapper_commands.ts
+++ b/src/extension/bazel_wrapper_commands.ts
@@ -13,11 +13,16 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
+import * as path from "path";
 
 import { IBazelCommandAdapter } from "../bazel/bazel_command";
 import { BazelWorkspaceInfo } from "../bazel/bazel_workspace_info";
 import { getDefaultBazelExecutablePath } from "./configuration";
-import { getBazelPackageFile } from "../bazel/bazel_utils";
+import {
+  getBazelPackageFile,
+  getBazelWorkspaceFolder,
+  getBazelPackageFolder,
+} from "../bazel/bazel_utils";
 import {
   queryQuickPickTargets,
   queryQuickPickPackage,
@@ -369,6 +374,80 @@ async function bazelGoToLabel(target_info?: blaze_query.ITarget | undefined) {
 }
 
 /**
+ * Copies the Bazel label to the clipboard.
+ *
+ * If no adapter is provided, it will find the label under the cursor in the
+ * active editor, validate it, and copy it to the clipboard. If the label is a
+ * short form (missing the target name), it will be expanded to the full label.
+ */
+function bazelCopyLabelToClipboard(adapter: IBazelCommandAdapter | undefined) {
+  let label: string;
+
+  if (adapter !== undefined) {
+    // Called from a command adapter, so we can assume there is only one target.
+    label = adapter.getBazelCommandOptions().targets[0];
+  } else {
+    // Called from command palette
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      vscode.window.showInformationMessage(
+        "Please open a file to copy a label from.",
+      );
+      return;
+    }
+
+    const document = editor.document;
+    const position = editor.selection.active;
+    const wordRange = document.getWordRangeAtPosition(
+      position,
+      /(?<![^"'])[a-zA-Z0-9_/:.-@]+(?![^"'])/,
+    );
+
+    if (!wordRange) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      vscode.window.showInformationMessage(
+        "No label found at cursor position.",
+      );
+      return;
+    }
+
+    label = document.getText(wordRange);
+
+    // If the label doesn't start with //, prepend the current package
+    if (!label.startsWith("//") && !label.startsWith("@")) {
+      const filePath = document.uri.fsPath;
+      const packagePath = getBazelPackageFolder(filePath);
+      if (!packagePath) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        vscode.window.showErrorMessage("Not in a Bazel package.");
+        return;
+      }
+
+      // Get the package relative to workspace
+      const workspaceRoot = getBazelWorkspaceFolder(filePath);
+      const relativePackage = path.relative(workspaceRoot, packagePath) || ".";
+      label = `//${relativePackage}${label.startsWith(":") ? "" : ":"}${label}`;
+    }
+
+    // Handle the case where the target name is omitted
+    // (e.g., "//foo/bar" instead of "//foo/bar:bar")
+    if (!label.includes(":")) {
+      const parts = label.split("/");
+      const lastPart = parts[parts.length - 1];
+      if (lastPart && lastPart !== "...") {
+        // Don't expand "//..."
+        label = `${label}:${lastPart}`;
+      }
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  vscode.env.clipboard.writeText(label);
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  vscode.window.showInformationMessage(`Copied to clipboard: ${label}`);
+}
+
+/**
  * Activate all user-facing commands which simply wrap Bazel commands
  * such as `build`, `clean`, etc.
  */
@@ -394,5 +473,9 @@ export function activateWrapperCommands(): vscode.Disposable[] {
     vscode.commands.registerCommand("bazel.clean", bazelClean),
     vscode.commands.registerCommand("bazel.goToBuildFile", bazelGoToBuildFile),
     vscode.commands.registerCommand("bazel.goToLabel", bazelGoToLabel),
+    vscode.commands.registerCommand(
+      "bazel.copyLabelToClipboard",
+      bazelCopyLabelToClipboard,
+    ),
   ];
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 
-import { activateTaskProvider, IBazelCommandAdapter } from "../bazel";
+import { activateTaskProvider } from "../bazel";
 import {
   BuildifierDiagnosticsManager,
   BuildifierFormatProvider,
@@ -101,10 +101,6 @@ export async function activate(context: vscode.ExtensionContext) {
       completionItemProvider?.refresh();
       workspaceTreeProvider.refresh();
     }),
-    vscode.commands.registerCommand(
-      "bazel.copyTargetToClipboard",
-      bazelCopyTargetToClipboard,
-    ),
     // URI handler
     vscode.window.registerUriHandler({
       async handleUri(uri: vscode.Uri) {
@@ -203,20 +199,4 @@ function createLsp(config: vscode.WorkspaceConfiguration) {
     serverOptions,
     clientOptions,
   );
-}
-
-/**
- * Copies a target to the clipboard.
- */
-function bazelCopyTargetToClipboard(adapter: IBazelCommandAdapter | undefined) {
-  if (adapter === undefined) {
-    // This command should not be enabled in the commands palette, so adapter
-    // should always be present.
-    return;
-  }
-  // This can only be called on single targets, so we can assume there is only
-  // one of them.
-  const target = adapter.getBazelCommandOptions().targets[0];
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  vscode.env.clipboard.writeText(target);
 }

--- a/test/bazel_workspace/pkg1/BUILD
+++ b/test/bazel_workspace/pkg1/BUILD
@@ -1,5 +1,17 @@
+# Note this file contains different kinds of labels on purpose - used by copy_label_to_clipboard test
+load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")  # external label
+py_library(
+    name="pkg1",  # Same label as package
+    srcs=glob(["subfolder/*.py"]),
+    imports=["subfolder"],
+)
+filegroup(
+    name="src_files",
+    srcs=["main.py"],  # relative file label
+)
 py_binary(
-    name = "main",
-    srcs = ["main.py"],
-    visibility = ["//visibility:public"],
+    name="main",  # name label
+    srcs=[":src_files"],  # relative target label
+    visibility=["//visibility:public"],  # Full label on purpose
+    deps=["//pkg1"],  # Short package label on purpose
 )

--- a/test/bazel_workspace/pkg1/main.py
+++ b/test/bazel_workspace/pkg1/main.py
@@ -1,5 +1,4 @@
-def main():
-    print("Hello, world!")
+from lib import hello_world
 
 if __name__ == "__main__":
-    main()
+    hello_world()

--- a/test/bazel_workspace/pkg1/subfolder/lib.py
+++ b/test/bazel_workspace/pkg1/subfolder/lib.py
@@ -1,0 +1,2 @@
+def hello_world():
+    print("Hello, world!")

--- a/test/copy_label_to_clipboard.test.ts
+++ b/test/copy_label_to_clipboard.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as vscode from "vscode";
+import * as path from "path";
+import * as assert from "assert";
+
+async function openSourceFile(sourceFile: string) {
+  const doc = await vscode.workspace.openTextDocument(
+    vscode.Uri.file(sourceFile),
+  );
+  const editor = await vscode.window.showTextDocument(
+    doc,
+    vscode.ViewColumn.One,
+    false,
+  );
+  return editor;
+}
+function setCursorInEditor(
+  editor: vscode.TextEditor,
+  anchor: vscode.Position,
+  active: vscode.Position,
+) {
+  editor.selection = new vscode.Selection(anchor, active);
+  editor.revealRange(new vscode.Range(anchor, active));
+}
+
+interface TestCase {
+  name: string;
+  cursorPos: vscode.Position;
+  expectedLabel: string;
+}
+
+describe("Copy Label To Clipboard", () => {
+  const workspacePath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "test",
+    "bazel_workspace",
+  );
+
+  const buildFilePath = path.join(workspacePath, "pkg1", "BUILD");
+  const testCases: TestCase[] = [
+    {
+      name: "should copy package name label to clipboard",
+      cursorPos: new vscode.Position(3, 14),
+      expectedLabel: "//pkg1:pkg1",
+    },
+    {
+      name: "should copy relative file label to clipboard",
+      cursorPos: new vscode.Position(9, 14),
+      expectedLabel: "//pkg1:main.py",
+    },
+    {
+      name: "should copy target name label to clipboard",
+      cursorPos: new vscode.Position(12, 13),
+      expectedLabel: "//pkg1:main",
+    },
+    {
+      name: "should copy relative target reference label to clipboard",
+      cursorPos: new vscode.Position(13, 15),
+      expectedLabel: "//pkg1:src_files",
+    },
+    {
+      name: "should copy full label to clipboard",
+      cursorPos: new vscode.Position(14, 20),
+      expectedLabel: "//visibility:public",
+    },
+    {
+      name: "should copy short package label in deps to clipboard",
+      cursorPos: new vscode.Position(15, 15),
+      expectedLabel: "//pkg1:pkg1",
+    },
+    {
+      name: "should copy external label to clipboard",
+      cursorPos: new vscode.Position(1, 15),
+      expectedLabel: "@local_config_platform//:constraints.bzl",
+    },
+    {
+      name: "should not misinterpret a rule name as a label",
+      cursorPos: new vscode.Position(7, 5),
+      expectedLabel: "",
+    },
+    {
+      name: "should not misinterpret an empty line as a label",
+      cursorPos: new vscode.Position(17, 0),
+      expectedLabel: "",
+    },
+    {
+      name: "should not misinterpret an attribute as a label",
+      cursorPos: new vscode.Position(14, 9),
+      expectedLabel: "",
+    },
+  ];
+
+  beforeEach(async () => {
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    await vscode.env.clipboard.writeText("");
+  });
+
+  testCases.forEach(({ name, cursorPos, expectedLabel }) => {
+    it(name, async () => {
+      const editor = await openSourceFile(buildFilePath);
+
+      // GIVEN
+      setCursorInEditor(editor, cursorPos, cursorPos);
+
+      // WHEN
+      await vscode.commands.executeCommand("bazel.copyLabelToClipboard");
+
+      // THEN
+      assert.strictEqual(await vscode.env.clipboard.readText(), expectedLabel);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the already existing (but hidden) command to the command palette to make it usable interactively.

To use it, place your cursor onto a label string inside an open text file.
If the string can be interpreted as a bazel label, the full label is formed and copied to the clipboard.

Part of #194 