### PR TITLE
fix: Use "go to" instead of "jump"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ This extension provides support for Bazel in Visual Studio.
 - **Bazel Task** definitions for `tasks.json`
 - **Coverage Support** showing coverage results from `bazel coverage` directly
   in VS Code.
-- **Code Navigation** to jump to BUILD files or labels
+- **Code Navigation** to go to BUILD files or labels
 - Debug Starlark code in your `.bzl` files during a build (set breakpoints, step
   through code, inspect variables, etc.)
-- URI handler to jump to targets from outside of VSCode. (Example: vscode://bazelbuild.vscode-bazel//path/to/tests:target)
+- URI handler to go to targets from outside of VSCode. (Example: vscode://bazelbuild.vscode-bazel//path/to/tests:target)
 
 ## Configuring the Extension
 

--- a/package.json
+++ b/package.json
@@ -88,13 +88,13 @@
             },
             {
                 "category": "Bazel",
-                "command": "bazel.jumpToBuildFile",
-                "title": "Jump to BUILD file"
+                "command": "bazel.goToBuildFile",
+                "title": "Go to BUILD file"
             },
             {
                 "category": "Bazel",
-                "command": "bazel.jumpToLabel",
-                "title": "Jump to Bazel Label"
+                "command": "bazel.goToLabel",
+                "title": "Go to Label"
             },
             {
                 "category": "Bazel",
@@ -362,11 +362,11 @@
                     "when": "bazel.haveWorkspace"
                 },
                 {
-                    "command": "bazel.jumpToBuildFile",
+                    "command": "bazel.goToBuildFile",
                     "when": "bazel.haveWorkspace"
                 },
                 {
-                    "command": "bazel.jumpToLabel",
+                    "command": "bazel.goToLabel",
                     "when": "bazel.haveWorkspace"
                 }
             ],

--- a/src/extension/bazel_wrapper_commands.ts
+++ b/src/extension/bazel_wrapper_commands.ts
@@ -301,18 +301,18 @@ async function bazelClean() {
 }
 
 /**
- * Jumps to the BUILD file for the current package.
+ * Navigates to the BUILD file for the current package.
  *
  * This command finds the nearest BUILD or BUILD.bazel file in the current file's
  * directory or any parent directory and opens it in the editor. The search is
  * limited to the current Bazel workspace.
  */
-async function bazelJumpToBuildFile() {
+async function bazelGoToBuildFile() {
   const currentEditor = vscode.window.activeTextEditor;
   if (!currentEditor) {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     vscode.window.showInformationMessage(
-      "Please open a file to jump to its BUILD file.",
+      "Please open a file to go to its BUILD file.",
     );
     return;
   }
@@ -333,13 +333,13 @@ async function bazelJumpToBuildFile() {
 }
 
 /**
- * Jumps to the BUILD file location for the specified label.
+ * Navigates to the BUILD file location for the specified label.
  *
  * This command finds the BUILD file location for the specified label and opens
  * it in the editor.
- * @param target_info Optional target information to jump to directly, bypassing the quick pick
+ * @param target_info Optional target information to go to directly, bypassing the quick pick
  */
-async function bazelJumpToLabel(target_info?: blaze_query.ITarget | undefined) {
+async function bazelGoToLabel(target_info?: blaze_query.ITarget | undefined) {
   if (!target_info) {
     const quickPick = await vscode.window.showQuickPick(
       queryQuickPickTargets({ query: "kind('.* rule', ...)" }),
@@ -392,10 +392,7 @@ export function activateWrapperCommands(): vscode.Disposable[] {
       bazelTestAllRecursive,
     ),
     vscode.commands.registerCommand("bazel.clean", bazelClean),
-    vscode.commands.registerCommand(
-      "bazel.jumpToBuildFile",
-      bazelJumpToBuildFile,
-    ),
-    vscode.commands.registerCommand("bazel.jumpToLabel", bazelJumpToLabel),
+    vscode.commands.registerCommand("bazel.goToBuildFile", bazelGoToBuildFile),
+    vscode.commands.registerCommand("bazel.goToLabel", bazelGoToLabel),
   ];
 }

--- a/src/workspace-tree/bazel_target_tree_item.ts
+++ b/src/workspace-tree/bazel_target_tree_item.ts
@@ -72,7 +72,7 @@ export class BazelTargetTreeItem
         { selection: location.range },
       ],
       command: "vscode.open",
-      title: "Jump to Build Target",
+      title: "Go to Build Target",
     };
   }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,2 +1,2 @@
-# This BUILD file is used for testing the jump to build file feature
+# This BUILD file is used for testing the go to build file feature
 # It is located one level above the bazel_workspace and should not be found as it's outside the bazel workspace

--- a/test/go_to_build_file.test.ts
+++ b/test/go_to_build_file.test.ts
@@ -23,7 +23,7 @@ interface TestCase {
   expectedBuildFile: string | null; // null means no BUILD file should be found
 }
 
-describe("Jump to Build File", () => {
+describe("Go to Build File", () => {
   const workspacePath = path.join(
     __dirname,
     "..",
@@ -82,7 +82,7 @@ describe("Jump to Build File", () => {
       assertEditorIsActive(sourceFile);
 
       // WHEN
-      await vscode.commands.executeCommand("bazel.jumpToBuildFile");
+      await vscode.commands.executeCommand("bazel.goToBuildFile");
 
       // THEN
       const expectedFile = expectedBuildFile || sourceFile;
@@ -100,7 +100,7 @@ describe("Jump to Build File", () => {
       errorShown = true;
     });
 
-    await vscode.commands.executeCommand("bazel.jumpToBuildFile");
+    await vscode.commands.executeCommand("bazel.goToBuildFile");
 
     // THEN
     assert.strictEqual(

--- a/test/go_to_label.test.ts
+++ b/test/go_to_label.test.ts
@@ -37,7 +37,7 @@ function assertEditorIsActive(
   );
 }
 
-describe("Jump to Label", () => {
+describe("Go to Label", () => {
   const workspacePath = path.join(
     __dirname,
     "..",
@@ -50,7 +50,7 @@ describe("Jump to Label", () => {
     await vscode.commands.executeCommand("workbench.action.closeAllEditors");
   });
 
-  it("should jump to correct line in BUILD file", async () => {
+  it("should go to correct line in BUILD file", async () => {
     // GIVEN
     const targetLabel = "//pkg1:main";
     const expectedFile = path.join(workspacePath, "pkg1", "BUILD");
@@ -64,7 +64,7 @@ describe("Jump to Label", () => {
     });
 
     // WHEN
-    await vscode.commands.executeCommand("bazel.jumpToLabel", mockTargetInfo);
+    await vscode.commands.executeCommand("bazel.goToLabel", mockTargetInfo);
 
     // THEN
     assertEditorIsActive(expectedFile, expectedLine, expectedCharacter);


### PR DESCRIPTION
This changes the terminology used in various commands from "go to" to "jump". This terminology is already used all over vscode, whereas jump is not. This was agreed in #463.