### PR TITLE
fix(definition): resolve package-relative labels in Go to Definition

### DIFF
--- a/src/bazel/bazel_utils.ts
+++ b/src/bazel/bazel_utils.ts
@@ -47,6 +47,36 @@ export function getPackageLabelForBuildFile(
 }
 
 /**
+ * Turn a possibly package-relative label into an absolute one.
+ *
+ * Labels that already start with `//` (this repository) or `@` (a named
+ * repository) are returned unchanged. A label starting with `:` refers to
+ * a target in the same package. Anything else is treated as a bare
+ * package-relative path (e.g. a source file), which becomes the target
+ * name within the package.
+ *
+ * Note this is a purely textual transformation: it has no knowledge of
+ * repository/module boundaries (e.g. a `local_path_override`'d nested
+ * module), so `packageLabel` must already be correct for the label's
+ * repository. See https://github.com/bazel-contrib/vscode-bazel/issues/416.
+ *
+ * @param target The label text as written in a BUILD/bzl file, e.g. "client.py", "subdir/client.py", ":lib", or "//pkg:target".
+ * @param packageLabel The absolute package label to resolve `target` against, e.g. "//pkg" (see getPackageLabelForBuildFile).
+ * @returns The absolute label.
+ */
+export function canonicalizeLabel(
+  target: string,
+  packageLabel: string,
+): string {
+  if (target.startsWith("//") || target.startsWith("@")) {
+    return target;
+  }
+  return target.startsWith(":")
+    ? `${packageLabel}${target}`
+    : `${packageLabel}:${target}`;
+}
+
+/**
  * Get the targets in the build file
  *
  * @param bazelExecutable The path to the Bazel executable.

--- a/src/completion-provider/bazel_completion_provider.ts
+++ b/src/completion-provider/bazel_completion_provider.ts
@@ -15,6 +15,7 @@
 import * as vscode from "vscode";
 import {
   BazelWorkspaceInfo,
+  canonicalizeLabel,
   getPackageLabelForBuildFile,
   queryQuickPickTargets,
 } from "../bazel";
@@ -76,7 +77,7 @@ function getAbsoluteLabel(
   target: string,
   document: vscode.TextDocument,
 ): string {
-  if (target.startsWith("//")) {
+  if (target.startsWith("//") || target.startsWith("@")) {
     return target;
   }
   const workspace = BazelWorkspaceInfo.fromDocument(document);
@@ -87,7 +88,7 @@ function getAbsoluteLabel(
     workspace.bazelWorkspacePath,
     document.uri.fsPath,
   );
-  return `${packageLabel}${target}`;
+  return canonicalizeLabel(target, packageLabel);
 }
 
 export class BazelCompletionItemProvider

--- a/src/definition/bazel_goto_definition_provider.ts
+++ b/src/definition/bazel_goto_definition_provider.ts
@@ -20,7 +20,12 @@ import {
   TextDocument,
   Uri,
 } from "vscode";
-import { BazelQuery, BazelWorkspaceInfo, QueryLocation } from "../bazel";
+import {
+  BazelQuery,
+  BazelWorkspaceInfo,
+  QueryLocation,
+  getPackageLabelForBuildFile,
+} from "../bazel";
 import { getBazelExecutablePath } from "../extension/configuration";
 import { blaze_query } from "../protos";
 
@@ -30,6 +35,7 @@ export const LABEL_REGEX = /"((?:@\w+)?\/\/|(?:.+\/)?[^:"]*(?::[^:"]+)?)"/;
 export async function targetToUri(
   targetText: string,
   workingDirectory: Uri,
+  packageLabel?: string,
 ): Promise<QueryLocation | undefined> {
   const match = LABEL_REGEX.exec(targetText);
 
@@ -37,10 +43,26 @@ export async function targetToUri(
     return undefined;
   }
 
-  const targetName = match[1];
+  let targetName = match[1];
   // don't try to process visibility targets.
   if (targetName.startsWith("//visibility")) {
     return undefined;
+  }
+
+  // Package-relative labels (e.g. "client.py", "subdir/client.py", or
+  // ":target") must be canonicalized to an absolute label before querying,
+  // since the query below always runs from the Bazel workspace root (not the
+  // BUILD file's package directory) so that it respects a pinned
+  // `bazel.workspacePath` root. Labels that are already absolute (starting
+  // with "//" or "@repo//") are left untouched.
+  if (
+    packageLabel &&
+    !targetName.startsWith("//") &&
+    !targetName.startsWith("@")
+  ) {
+    targetName = targetName.startsWith(":")
+      ? `${packageLabel}${targetName}`
+      : `${packageLabel}:${targetName}`;
   }
 
   const queryResult = await new BazelQuery(
@@ -85,9 +107,14 @@ export class BazelGotoDefinitionProvider implements DefinitionProvider {
     const range = document.getWordRangeAtPosition(position, LABEL_REGEX);
     const targetText = document.getText(range);
 
+    const packageLabel = getPackageLabelForBuildFile(
+      workspaceInfo.bazelWorkspacePath,
+      document.uri.fsPath,
+    );
     const location = await targetToUri(
       targetText,
       Uri.file(workspaceInfo.bazelWorkspacePath),
+      packageLabel,
     );
 
     return location

--- a/src/definition/bazel_goto_definition_provider.ts
+++ b/src/definition/bazel_goto_definition_provider.ts
@@ -24,6 +24,7 @@ import {
   BazelQuery,
   BazelWorkspaceInfo,
   QueryLocation,
+  canonicalizeLabel,
   getPackageLabelForBuildFile,
 } from "../bazel";
 import { getBazelExecutablePath } from "../extension/configuration";
@@ -53,16 +54,9 @@ export async function targetToUri(
   // ":target") must be canonicalized to an absolute label before querying,
   // since the query below always runs from the Bazel workspace root (not the
   // BUILD file's package directory) so that it respects a pinned
-  // `bazel.workspacePath` root. Labels that are already absolute (starting
-  // with "//" or "@repo//") are left untouched.
-  if (
-    packageLabel &&
-    !targetName.startsWith("//") &&
-    !targetName.startsWith("@")
-  ) {
-    targetName = targetName.startsWith(":")
-      ? `${packageLabel}${targetName}`
-      : `${packageLabel}:${targetName}`;
+  // `bazel.workspacePath` root.
+  if (packageLabel) {
+    targetName = canonicalizeLabel(targetName, packageLabel);
   }
 
   const queryResult = await new BazelQuery(

--- a/test/bazel_utils.test.ts
+++ b/test/bazel_utils.test.ts
@@ -9,6 +9,7 @@ import {
   getTargetNameAtBuildFileLocation,
   getBazelWorkspaceFolder,
   getBazelWorkspaceRelativePath,
+  canonicalizeLabel,
 } from "../src/bazel/bazel_utils";
 
 const workspacePath = path.join(
@@ -318,5 +319,47 @@ describe("Bazel Utils: getBazelWorkspaceRelativePath", () => {
       ),
       undefined,
     );
+  });
+});
+
+describe("Bazel Utils: canonicalizeLabel", () => {
+  it("leaves an absolute label unchanged", () => {
+    assert.strictEqual(
+      canonicalizeLabel("//pkg:target", "//other"),
+      "//pkg:target",
+    );
+  });
+
+  it("leaves a package-only label unchanged", () => {
+    assert.strictEqual(canonicalizeLabel("//pkg/sub", "//other"), "//pkg/sub");
+  });
+
+  it("leaves an external repository label unchanged", () => {
+    assert.strictEqual(
+      canonicalizeLabel("@repo//pkg:target", "//other"),
+      "@repo//pkg:target",
+    );
+  });
+
+  it("resolves a same-package target label against the package", () => {
+    assert.strictEqual(canonicalizeLabel(":target", "//pkg"), "//pkg:target");
+  });
+
+  it("resolves a bare file label against the package", () => {
+    assert.strictEqual(
+      canonicalizeLabel("client.py", "//pkg"),
+      "//pkg:client.py",
+    );
+  });
+
+  it("resolves a bare file label in a subdirectory against the package", () => {
+    assert.strictEqual(
+      canonicalizeLabel("subdir/client.py", "//pkg"),
+      "//pkg:subdir/client.py",
+    );
+  });
+
+  it("resolves a bare label against the root package", () => {
+    assert.strictEqual(canonicalizeLabel("client.py", "//"), "//:client.py");
   });
 });

--- a/test/goto_definition_provider.test.ts
+++ b/test/goto_definition_provider.test.ts
@@ -85,12 +85,24 @@ describe("BazelGotoDefinitionProvider", () => {
     sandbox.restore();
   });
 
-  it("runs its query from the resolved Bazel workspace root", async () => {
-    const bazelWorkspacePath = "/workspace/root";
+  // Regression test helper for
+  // https://github.com/bazel-contrib/vscode-bazel/issues/696: package-relative
+  // labels (e.g. srcs = ["client.py"]) must resolve relative to the BUILD
+  // file's package, even though the query itself always runs with the
+  // resolved Bazel workspace root as its cwd (so that it keeps respecting a
+  // pinned `bazel.workspacePath` root, per #687). Stubs `queryTargets`,
+  // asserts its cwd is always the workspace root, and returns the stub (to
+  // assert on the canonicalized query text) plus a `run` function that
+  // invokes `provideDefinition` for a given document/label.
+  function stubGotoDefinition(
+    bazelWorkspacePath: string,
+    documentPath: string,
+    labelText: string,
+  ) {
     sandbox.stub(BazelWorkspaceInfo, "fromDocument").returns({
       bazelWorkspacePath,
     } as BazelWorkspaceInfo);
-    const queryTargets = sandbox
+    const query = sandbox
       .stub(BazelQuery.prototype, "queryTargets")
       .callsFake(async function (this: BazelQuery) {
         assert.strictEqual(this.workingDirectory, bazelWorkspacePath);
@@ -101,25 +113,119 @@ describe("BazelGotoDefinitionProvider", () => {
               rule: {
                 name: "//pkg:target",
                 ruleClass: "filegroup",
-                location: "/workspace/root/pkg/BUILD:1:1",
+                location: `${bazelWorkspacePath}/pkg/BUILD:1:1`,
               },
             },
           ],
         });
       });
-    const range = new vscode.Range(0, 0, 0, 14);
+    const range = new vscode.Range(0, 0, 0, labelText.length);
     const document = {
-      uri: vscode.Uri.file("/workspace/root/nested/pkg/BUILD"),
+      uri: vscode.Uri.file(documentPath),
       getWordRangeAtPosition: () => range,
-      getText: () => '"//pkg:target"',
+      getText: () => labelText,
     } as unknown as vscode.TextDocument;
 
-    const result = await new BazelGotoDefinitionProvider().provideDefinition(
-      document,
-      new vscode.Position(0, 5),
+    return {
+      query,
+      run: () =>
+        new BazelGotoDefinitionProvider().provideDefinition(
+          document,
+          new vscode.Position(0, 5),
+        ),
+    };
+  }
+
+  it("queries an absolute label from the resolved workspace root", async () => {
+    const bazelWorkspacePath = "/workspace/root";
+    const { query, run } = stubGotoDefinition(
+      bazelWorkspacePath,
+      "/workspace/root/nested/pkg/BUILD",
+      '"//pkg:target"',
     );
 
-    assert.strictEqual(queryTargets.callCount, 1);
+    const result = await run();
+
+    assert.strictEqual(query.callCount, 1);
+    assert.match(query.firstCall.args[0], /"\/\/pkg:target"/);
     assert.ok(Array.isArray(result));
+  });
+
+  it("keeps an external repository label unchanged", async () => {
+    const bazelWorkspacePath = "/workspace/root";
+    const { query, run } = stubGotoDefinition(
+      bazelWorkspacePath,
+      "/workspace/root/pkg/BUILD",
+      '"@repo//pkg:target"',
+    );
+
+    await run();
+
+    assert.match(query.firstCall.args[0], /"@repo\/\/pkg:target"/);
+  });
+
+  it("canonicalizes a bare package-relative file label", async () => {
+    const bazelWorkspacePath = "/workspace/root";
+    const { query, run } = stubGotoDefinition(
+      bazelWorkspacePath,
+      "/workspace/root/pkg/BUILD",
+      '"client.py"',
+    );
+
+    await run();
+
+    assert.match(query.firstCall.args[0], /"\/\/pkg:client\.py"/);
+  });
+
+  it("canonicalizes a package-relative label in a subdirectory", async () => {
+    const bazelWorkspacePath = "/workspace/root";
+    const { query, run } = stubGotoDefinition(
+      bazelWorkspacePath,
+      "/workspace/root/pkg/BUILD",
+      '"subdir/client.py"',
+    );
+
+    await run();
+
+    assert.match(query.firstCall.args[0], /"\/\/pkg:subdir\/client\.py"/);
+  });
+
+  it("canonicalizes a colon-only same-package target label", async () => {
+    const bazelWorkspacePath = "/workspace/root";
+    const { query, run } = stubGotoDefinition(
+      bazelWorkspacePath,
+      "/workspace/root/pkg/BUILD",
+      '":target"',
+    );
+
+    await run();
+
+    assert.match(query.firstCall.args[0], /"\/\/pkg:target"/);
+  });
+
+  it("canonicalizes a package-relative Starlark file", async () => {
+    const bazelWorkspacePath = "/workspace/root";
+    const { query, run } = stubGotoDefinition(
+      bazelWorkspacePath,
+      "/workspace/root/pkg/BUILD",
+      '"helpers.bzl"',
+    );
+
+    await run();
+
+    assert.match(query.firstCall.args[0], /"\/\/pkg:helpers\.bzl"/);
+  });
+
+  it("canonicalizes a relative label at the workspace root", async () => {
+    const bazelWorkspacePath = "/workspace/root";
+    const { query, run } = stubGotoDefinition(
+      bazelWorkspacePath,
+      "/workspace/root/BUILD",
+      '"client.py"',
+    );
+
+    await run();
+
+    assert.match(query.firstCall.args[0], /"\/\/:client\.py"/);
   });
 });


### PR DESCRIPTION
## Bug

Fixes #696

> Go to Definition fails for package-relative source labels such as `srcs = ["client.py"]`. The provider extracts `client.py` correctly, but runs the Bazel query from the Bazel workspace root, so Bazel resolves the label as `//:client.py` instead of `//pkg:client.py`, and the query fails with `ERROR: no such target '//:client.py'`.

This is a regression from #687 (commit bfb8a70), which changed the query's working directory from the BUILD file's directory
(`Utils.dirname(document.uri)`) to the resolved Bazel workspace root (`Uri.file(workspaceInfo.bazelWorkspacePath)`), in order to respect a manually pinned `bazel.workspacePath` when a nested `MODULE.bazel`/ `WORKSPACE` would otherwise confuse Bazel's own upward root search (see #684, scenarios S4/S5). That fixed root-pinning for absolute labels (`//pkg:target`) but broke Bazel's relative-label resolution, since Bazel resolves any label without a leading `//`/`@repo//` against the query process's cwd.

Simply reverting to the BUILD file's directory as the query cwd is not an option, since it would let Bazel's own upward directory search rediscover the wrong nested `MODULE.bazel` from inside a sub-package, silently undoing the #687/#684 fix.

## Fix

Keep the query's cwd pinned at the resolved Bazel workspace root, but canonicalize the label text itself to an absolute label (`//pkg:name`) before querying, using the existing `getPackageLabelForBuildFile()` helper. This matches the pattern already used elsewhere in the codebase (CodeLens provider, Document Symbol provider, completion provider's `getAbsoluteLabel`), which always query from the workspace root and pre-resolve relative labels instead of relying on process cwd.

`targetToUri()` gains an optional `packageLabel` parameter; labels that already start with `//` or `@` (absolute, or external-repo) are left untouched. The `vscode://` URI handler, the other caller of `targetToUri`, is unaffected — its input is always a full `//path/to:target` label already, so it simply omits the new argument.

## Testing

- Rewrote and extended `test/goto_definition_provider.test.ts` with regression coverage for `"client.py"`, `"subdir/client.py"`, `":target"`, a package-relative `.bzl` file, a package-relative label at the workspace root, plus the pre-existing absolute (`//pkg:target`) and external-repo (`@repo//pkg:target`) cases — all asserting the query cwd stays the workspace root while the label text is canonicalized as needed.
- `npm run typecheck`, `npm run lint-check`, `npm run format-check` all pass.
- `xvfb-run -a npm run test:unit`: all `BazelGotoDefinitionProvider` tests pass. Verified via `git stash` that the small number of unrelated pre-existing failures in this environment (extension-activation/ command-registration issues) are present identically on `master` without this change, i.e. not a regression introduced here.
